### PR TITLE
Add ability to specify security groups used by ECS task

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,8 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.this.arn
     network_configuration {
-      subnets = var.subnet_ids
+      subnets         = var.subnet_ids
+      security_groups = var.security_group_ids
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,11 @@ variable "subnet_ids" {
   description = "Subnets where the job will be run"
 }
 
+variable "security_group_ids" {
+  type        = list(string)
+  description = "Security groups to associate with the job"
+}
+
 variable "cloudwatch_schedule_expression" {
   type        = string
   description = "AWS cron schedule expression"


### PR DESCRIPTION
Like it says on the tin. Often security groups are used to restrict application access to RDS - the backup cron task should have the same.